### PR TITLE
#comment removed link since its not needed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub use Synchronization::*;
 
 use raw::*;
 
-#[link(name = "rt")]
+//#[link(name = "rt")]
 extern {
     fn clock_gettime(clkid: libc::c_int, res: *mut libc::timespec);
 }


### PR DESCRIPTION

Most of the targets `clock_gettime` already have them as part of their targets particularly with this test

--target=armv7-unknown-linux-musleabihf

